### PR TITLE
Bug fix for ABS on resize

### DIFF
--- a/js/adapt-articleView.js
+++ b/js/adapt-articleView.js
@@ -21,7 +21,7 @@ define([
 
         _blockSliderPreRender: function() {
             this._disableAnimations = $('html').is(".ie8") || $('html').is(".iPhone.version-7\\.0");
-            if (this._blockSliderIsEnabledOnScreenSizes()) this._blockSliderSetupEventListeners();
+            this._blockSliderSetupEventListeners();
         },
 
         _blockSliderSetupEventListeners: function() {
@@ -42,7 +42,7 @@ define([
 
         render: function() {
 
-            if (this.model.isBlockSliderEnabled() && this._blockSliderIsEnabledOnScreenSizes()) {
+            if (this.model.isBlockSliderEnabled() {
 
                 this._blockSliderRender();
 


### PR DESCRIPTION
If viewed below 760 screen width and then increased above, ABS functionality does not trigger when it's meant to - bug fix which allows ABS to trigger correctly.
