### PR TITLE
add call to trigger articleView:render event

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "git://github.com/cgkineo/adapt-articleBlockSlider.git"
   },
-  "version": "3.0.0",
+  "version": "3.0.1",
   "framework": ">=5",
   "homepage": "https://github.com/cgkineo/adapt-articleBlockSlider",
   "issues": "https://github.com/cgkineo/adapt-articleBlockSlider/issues/",

--- a/js/adapt-articleView.js
+++ b/js/adapt-articleView.js
@@ -46,7 +46,7 @@ define([
 
     _blockSliderSetupEventListeners: function() {
 
-      this._blockSliderResizeHeight = _.bind(this._blockSliderResizeHeight, this);
+      this._blockSliderResizeHeight = this._blockSliderResizeHeight.bind(this);
 
       this.listenTo(Adapt, {
         "device:resize": this._onBlockSliderResize,

--- a/js/adapt-articleView.js
+++ b/js/adapt-articleView.js
@@ -60,7 +60,7 @@ define([
 
       var duration = this.model.get("_articleBlockSlider")._slideAnimationDuration || 200;
 
-      this._blockSliderHideOthers = debounce(_.bind(this._blockSliderHideOthers, this), duration);
+      this._blockSliderHideOthers = debounce(this._blockSliderHideOthers.bind(this), duration);
 
     },
 
@@ -82,6 +82,8 @@ define([
       var data = this.model.toJSON();
       var template = Handlebars.templates['articleBlockSlider-article'];
       this.$el.html(template(data));
+      
+      Adapt.trigger(this.constructor.type + 'View:render', this);
 
       this.addChildren();
 


### PR DESCRIPTION
fixes #46 

Also change instance of `_.bind` to `Function.bind`

Out of interest, anyone know why this has its own implementation of 'debounce' rather than using the underscore one?